### PR TITLE
Fix errors 1170 and 1071, and support UTF8

### DIFF
--- a/backends/database/database.go
+++ b/backends/database/database.go
@@ -9,7 +9,7 @@ import (
 
 type Translation struct {
 	Locale string `sql:"size:12;"`
-	Key    string `sql:"size:4294967295;"`
+	Key    string `sql:"size:255;"`
 	Value  string `sql:"size:4294967295"`
 }
 


### PR DESCRIPTION
Fix error 1170: BLOB/TEXT column 'key' used in key specification without a key length
Fix error 1071: Specified key was too long; max key length is 767 bytes
Support UTF8 (three bytes per character)