### PR TITLE
Add http.FileSystem handling to YAML backend

### DIFF
--- a/backends/yaml/tests/subdir/german.yml
+++ b/backends/yaml/tests/subdir/german.yml
@@ -1,0 +1,5 @@
+de:
+  hello: Hallo
+  user:
+    name: "Benutzername"
+    email: "E-Mail-Adresse"

--- a/backends/yaml/tests/subdir/no_language_file.txt
+++ b/backends/yaml/tests/subdir/no_language_file.txt
@@ -1,0 +1,1 @@
+This is not a language YAML file.

--- a/backends/yaml/yaml_test.go
+++ b/backends/yaml/yaml_test.go
@@ -1,28 +1,32 @@
 package yaml_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/qor/i18n"
 	"github.com/qor/i18n/backends/yaml"
 )
 
-func TestLoadTranslations(t *testing.T) {
-	backend := yaml.New("tests")
-	translations := backend.LoadTranslations()
+var values = map[string][][]string{
+	"en": {
+		{"hello", "Hello"},
+		{"user.name", "User Name"},
+		{"user.email", "Email"},
+	},
+	"de": {
+		{"hello", "Hallo"},
+		{"user.name", "Benutzername"},
+		{"user.email", "E-Mail-Adresse"},
+	},
+	"zh-CN": {
+		{"hello", "你好"},
+		{"user.name", "用户名"},
+		{"user.email", "邮箱"},
+	},
+}
 
-	values := map[string][][]string{
-		"en": {
-			{"hello", "Hello"},
-			{"user.name", "User Name"},
-			{"user.email", "Email"},
-		},
-		"zh-CN": {
-			{"hello", "你好"},
-			{"user.name", "用户名"},
-			{"user.email", "邮箱"},
-		},
-	}
-
+func checkTranslations(translations []*i18n.Translation) error {
 	for locale, results := range values {
 		for _, result := range results {
 			var found bool
@@ -32,8 +36,16 @@ func TestLoadTranslations(t *testing.T) {
 				}
 			}
 			if !found {
-				t.Errorf("failed to found translation %v for %v", result[0], locale)
+				return fmt.Errorf("failed to found translation %v for %v", result[0], locale)
 			}
 		}
+	}
+	return nil
+}
+
+func TestLoadTranslations(t *testing.T) {
+	backend := yaml.New("tests", "tests/subdir")
+	if err := checkTranslations(backend.LoadTranslations()); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/backends/yaml/yaml_test.go
+++ b/backends/yaml/yaml_test.go
@@ -49,3 +49,38 @@ func TestLoadTranslations(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestLoadTranslationsWalk(t *testing.T) {
+	backend := yaml.NewWithWalk("tests")
+	if err := checkTranslations(backend.LoadTranslations()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+var benchmarkResult error
+
+func BenchmarkLoadTranslations(b *testing.B) {
+	var backend i18n.Backend
+	var err error
+	for i := 0; i < b.N; i++ {
+		backend = yaml.New("tests", "tests/subdir")
+		if err = checkTranslations(backend.LoadTranslations()); err != nil {
+			b.Fatal(err)
+		}
+	}
+	benchmarkResult = err
+}
+
+var benchmarkResult2 error
+
+func BenchmarkLoadTranslationsWalk(b *testing.B) {
+	var backend i18n.Backend
+	var err error
+	for i := 0; i < b.N; i++ {
+		backend = yaml.NewWithWalk("tests")
+		if err = checkTranslations(backend.LoadTranslations()); err != nil {
+			b.Fatal(err)
+		}
+	}
+	benchmarkResult2 = err
+}

--- a/backends/yaml/yaml_test.go
+++ b/backends/yaml/yaml_test.go
@@ -2,6 +2,7 @@ package yaml_test
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/qor/i18n"
@@ -50,6 +51,13 @@ func TestLoadTranslations(t *testing.T) {
 	}
 }
 
+func TestLoadTranslationsFilesystem(t *testing.T) {
+	backend := yaml.NewWithFilesystem(http.Dir("./tests"))
+	if err := checkTranslations(backend.LoadTranslations()); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestLoadTranslationsWalk(t *testing.T) {
 	backend := yaml.NewWithWalk("tests")
 	if err := checkTranslations(backend.LoadTranslations()); err != nil {
@@ -83,4 +91,18 @@ func BenchmarkLoadTranslationsWalk(b *testing.B) {
 		}
 	}
 	benchmarkResult2 = err
+}
+
+var benchmarkResult3 error
+
+func BenchmarkLoadTranslationsFilesystem(b *testing.B) {
+	var backend i18n.Backend
+	var err error
+	for i := 0; i < b.N; i++ {
+		backend = yaml.NewWithFilesystem(http.Dir("./tests"))
+		if err = checkTranslations(backend.LoadTranslations()); err != nil {
+			b.Fatal(err)
+		}
+	}
+	benchmarkResult3 = err
 }


### PR DESCRIPTION
This adds the ability to use an `http.FileSystem`-based file tree as the container of translation files. One example is `http.Dir("./path/to/directory")`. This is especially useful for projects that embed all necessary assets (images, styles, JS etc. as well as template and locale files) inside the compiled Go binary using something like https://github.com/shurcooL/vfsgen.

This does not contain any breaking changes apart from the fact that it now eagerly loads the translation files when instantiating a YAML backend. Users can simply upgrade.

I also added benchmarks for the various usage scenarios – if you want you can replace the current `New` version with the `NewWithWalk` implementation; both load from a file tree and do the same thing. `NewWithWalk` has a simpler implementation and is faster and more memory-efficient than the old `New` implementation.
