### PR TITLE
fix: Failed to create unique index Error 1170

### DIFF
--- a/backends/database/database.go
+++ b/backends/database/database.go
@@ -10,7 +10,7 @@ import (
 // Translation is a struct used to save translations into databae
 type Translation struct {
 	Locale string `sql:"size:12;"`
-	Key    string `sql:"size:4294967295;"`
+	Key    string `gorm:"type:varchar(500);size:4294967295;"`
 	Value  string `sql:"size:4294967295"`
 }
 


### PR DESCRIPTION
quick fix for "Failed to create unique index for translations key & locale, got: Error 1170: BLOB/TEXT column 'key' used in key specification without a key length"